### PR TITLE
remove password from nep-6

### DIFF
--- a/neo-course.js
+++ b/neo-course.js
@@ -18,11 +18,6 @@ if (typeof privateKey === 'undefined') {
   console.log('The PRIVATE_KEY environment variable is not defined.')
   process.exit(1)
 }
-const password = process.env.PASSWORD
-if (typeof password === 'undefined') {
-  console.log('The PASSWORD environment variable is not defined.')
-  process.exit(1)
-}
 
 const recordTypes = {
   ipv4: 1,
@@ -347,8 +342,7 @@ function checkType (type) {
 }
 
 (async () => {
-  const decryptedPrivateKey = await wallet.decrypt(privateKey, password)
-  const account = new wallet.Account(decryptedPrivateKey)
+  const account = new wallet.Account(privateKey)
   console.log(`Address: ${account.address} / 0x${account.scriptHash}`)
   const rpcClient = new rpc.RPCClient(URL)
 


### PR DESCRIPTION
Password is for an NEP-2 standard wallet, it's not necessary here since already got private key and can be converted to standard address directly.
Reference: https://github.com/neo-project/proposals/blob/master/nep-2.mediawiki